### PR TITLE
timer-resolution-control: Force limits immediately on mod load and setting change, restore original resolution on mod unload

### DIFF
--- a/mods/timer-resolution-control.wh.cpp
+++ b/mods/timer-resolution-control.wh.cpp
@@ -262,8 +262,6 @@ void EnforceLimits() {
             }
         }
     }
-
-    //TODO: for background programs set timer resolution to 100ms
 }
 
 void Wh_ModAfterInit(void) {  

--- a/mods/timer-resolution-control.wh.cpp
+++ b/mods/timer-resolution-control.wh.cpp
@@ -2,21 +2,13 @@
 // @id           timer-resolution-control
 // @name         Timer Resolution Control
 // @description  Prevent programs from changing the Windows timer resolution and increasing power consumption
-// @version      1.0
+// @version      1.1
 // @author       m417z
 // @github       https://github.com/m417z
 // @twitter      https://twitter.com/m417z
 // @homepage     https://m417z.com/
 // @include      *
 // ==/WindhawkMod==
-
-// Source code is published under The GNU General Public License v3.0.
-//
-// For bug reports and feature requests, please open an issue here:
-// https://github.com/ramensoftware/windhawk-mods/issues
-//
-// For pull requests, development takes place here:
-// https://github.com/m417z/my-windhawk-mods
 
 // ==WindhawkModReadme==
 /*
@@ -29,8 +21,9 @@ to determine which programs are allowed to change the timer resolution.
 More details:
 [Windows Timer Resolution: Megawatts Wasted](https://randomascii.wordpress.com/2013/07/08/windows-timer-resolution-megawatts-wasted/)
 
-The changes will apply the next time the target program(s) will change the timer resolution. To make
-sure the changes apply, you might want to restart the target program(s) or restart the computer.
+The changes will apply immediately when the mod loads or when settings are changed.
+
+Authors: m417z, levitation
 */
 // ==/WindhawkModReadme==
 
@@ -74,6 +67,7 @@ enum class Config {
 ULONG g_minimumResolution;
 ULONG g_maximumResolution;
 ULONG g_limitResolution;
+ULONG g_lastDesiredResolution;
 
 Config ConfigFromString(PCWSTR string) {
     if (wcscmp(string, L"block") == 0) {
@@ -98,6 +92,8 @@ NTSTATUS WINAPI NtSetTimerResolutionHook(ULONG DesiredResolution, BOOLEAN SetRes
     }
 
     Wh_Log(L"> DesiredResolution: %f milliseconds", (double)DesiredResolution / 10000.0);
+
+    g_lastDesiredResolution = DesiredResolution;
 
     ULONG limitResolution = g_limitResolution;
     if (DesiredResolution < limitResolution) {
@@ -215,14 +211,17 @@ BOOL Wh_ModInit(void)
     ULONG CurrentResolution;
     NTSTATUS status = ((NTSTATUS(WINAPI*)(PULONG, PULONG, PULONG))pNtQueryTimerResolution)(
         &MinimumResolution, &MaximumResolution, &CurrentResolution);
-    if (NT_SUCCESS(status)) {
-        Wh_Log(L"NtQueryTimerResolution: min=%f, max=%f, current=%f",
-            (double)MinimumResolution / 10000.0,
-            (double)MaximumResolution / 10000.0,
-            (double)CurrentResolution / 10000.0);
-        g_minimumResolution = MinimumResolution;
-        g_maximumResolution = MaximumResolution;
+    if (!NT_SUCCESS(status)) {
+        return FALSE;
     }
+
+    Wh_Log(L"NtQueryTimerResolution: min=%f, max=%f, current=%f",
+        (double)MinimumResolution / 10000.0,
+        (double)MaximumResolution / 10000.0,
+        (double)CurrentResolution / 10000.0);
+    g_minimumResolution = MinimumResolution;
+    g_maximumResolution = MaximumResolution;
+    g_lastDesiredResolution = CurrentResolution;    //TODO: During mod load there is a small race condition where the hook is not yet set, the g_lastDesiredResolution is already set, and then the program tries to set a new desired resolution which will not be saved into g_lastDesiredResolution.
 
     LoadSettings();
 
@@ -231,9 +230,58 @@ BOOL Wh_ModInit(void)
     return TRUE;
 }
 
-void Wh_ModSettingsChanged(void)
-{
+void EnforceLimits() {
+
+    ULONG CurrentResolution;
+    NTSTATUS status = pOriginalNtSetTimerResolution(0, FALSE, &CurrentResolution);
+    if (NT_SUCCESS(status)) {
+        Wh_Log(L"NtGetTimerResolution: current=%f", (double)CurrentResolution / 10000.0);
+
+        ULONG limitResolution = g_limitResolution;
+        ULONG lastDesiredResolution = g_lastDesiredResolution;
+        if (CurrentResolution < limitResolution
+            || CurrentResolution < lastDesiredResolution) {
+
+            Wh_Log(L"> CurrentResolution: %f milliseconds", (double)CurrentResolution / 10000.0);
+
+            if (lastDesiredResolution < limitResolution) {
+                Wh_Log(L"* Overriding resolution: %f milliseconds", (double)limitResolution / 10000.0);
+                pOriginalNtSetTimerResolution(limitResolution, TRUE, &CurrentResolution);
+            }
+            else {
+                Wh_Log(L"* Restoring resolution: %f milliseconds", (double)lastDesiredResolution / 10000.0);
+                pOriginalNtSetTimerResolution(lastDesiredResolution, TRUE, &CurrentResolution);
+            }
+        }
+    }
+
+    //TODO: for background programs set timer resolution to 100ms
+}
+
+void Wh_ModAfterInit(void) {  
+
+    //Force timer resolution if it was already changed. NB! In order to avoid any race conditions, do this only after the hook is activated. Else there might be a situation that the mod overrides the current resolution while hook is not yet set. And then the program changes it again before the hook is finally set.
+
+    EnforceLimits();
+}
+
+void Wh_ModSettingsChanged(void) {
+
     Wh_Log(L"SettingsChanged");
 
     LoadSettings();
+
+    EnforceLimits();
 }
+
+void Wh_ModUninit() {
+
+    Wh_Log(L"Uniniting...");
+
+    //Lift all limits and restore original resolution set by the program
+    ULONG lastDesiredResolution = g_lastDesiredResolution;
+    Wh_Log(L"Restoring desired resolution: %f milliseconds", (double)lastDesiredResolution / 10000.0);
+    ULONG CurrentResolution;
+    pOriginalNtSetTimerResolution(g_lastDesiredResolution, TRUE, &CurrentResolution);
+}
+

--- a/mods/timer-resolution-control.wh.cpp
+++ b/mods/timer-resolution-control.wh.cpp
@@ -241,11 +241,12 @@ BOOL Wh_ModInit(void)
     return TRUE;
 }
 
-void EnforceLimits() {
-
+void EnforceLimits() 
+{
     ULONG CurrentResolution;
     NTSTATUS status = pOriginalNtSetTimerResolution(0, FALSE, &CurrentResolution);
     if (status == STATUS_TIMER_RESOLUTION_NOT_SET) {
+        Wh_Log(L"NtSetTimerResolution has not been called by the program");
         status = STATUS_SUCCESS;
         CurrentResolution = g_lastDesiredResolution;    //Take the value obtained from NtQueryTimerResolution, which does not fail with STATUS_TIMER_RESOLUTION_NOT_SET. Even if the program has not set the resolution, I have observed that the system itself may have set the resolution on program start to 1ms for some reason.
     }
@@ -274,15 +275,15 @@ void EnforceLimits() {
     }
 }
 
-void Wh_ModAfterInit(void) {  
-
-    //Force timer resolution if it was already changed. NB! In order to avoid any race conditions, do this only after the hook is activated. Else there might be a situation that the mod overrides the current resolution while hook is not yet set. And then the program changes it again before the hook is finally set.
+void Wh_ModAfterInit(void) 
+{  
+    //Force mod timer resolution settings if the resolution was already changed by the program. NB! In order to avoid any race conditions, do this only after the hook is activated. Else there might be a situation that the mod overrides the current resolution while hook is not yet set, and then the program changes it again before the hook is finally set.
 
     EnforceLimits();
 }
 
-void Wh_ModSettingsChanged(void) {
-
+void Wh_ModSettingsChanged(void) 
+{
     Wh_Log(L"SettingsChanged");
 
     LoadSettings();
@@ -290,8 +291,8 @@ void Wh_ModSettingsChanged(void) {
     EnforceLimits();
 }
 
-void Wh_ModUninit() {
-
+void Wh_ModUninit() 
+{
     Wh_Log(L"Uniniting...");
 
     //Lift all limits and restore original resolution set by the program

--- a/mods/timer-resolution-control.wh.cpp
+++ b/mods/timer-resolution-control.wh.cpp
@@ -10,6 +10,14 @@
 // @include      *
 // ==/WindhawkMod==
 
+// Source code is published under The GNU General Public License v3.0.
+//
+// For bug reports and feature requests, please open an issue here:
+// https://github.com/ramensoftware/windhawk-mods/issues
+//
+// For pull requests, development takes place here:
+// https://github.com/m417z/my-windhawk-mods
+
 // ==WindhawkModReadme==
 /*
 # Timer Resolution Control


### PR DESCRIPTION
timer-resolution-control: During mod start, force timer resolution limit if the resolution was already changed by the program. During settings change, enforce the new settings immediately by enforcing new limits or restoring the resolution desired earlier by the program. On mod unload restore the resolution desired by the program.