### PR TITLE
Added SearchHost.exe to target processes

### DIFF
--- a/mods/windows-11-start-menu-styler.wh.cpp
+++ b/mods/windows-11-start-menu-styler.wh.cpp
@@ -2,12 +2,13 @@
 // @id              windows-11-start-menu-styler
 // @name            Windows 11 Start Menu Styler
 // @description     Customize the start menu with themes contributed by others or create your own
-// @version         1.1.6
+// @version         1.1.7
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
 // @homepage        https://m417z.com/
 // @include         StartMenuExperienceHost.exe
+// @include         SearchHost.exe
 // @architecture    x86-64
 // @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject -lversion -Wl,--export-all-symbols
 // ==/WindhawkMod==


### PR DESCRIPTION
Start menu styles look awesome. However, we're back to old boring experience as soon as any key is pressed. 

SearchHost.exe is the window that opens up as soon as you press any key to search for an app or document. It has pretty similar structure to the StartMenuExperienceHost.exe. 
I haven't check if all the themes work with it. But for me it's definitely better than having to face with the stock window.