### PR TITLE
[Taskbar tray system icon tweaks] Separate options for language bar supplementary icons

### DIFF
--- a/mods/taskbar-tray-system-icon-tweaks.wh.cpp
+++ b/mods/taskbar-tray-system-icon-tweaks.wh.cpp
@@ -373,6 +373,12 @@ SystemTrayIconIdent IdentifySystemTrayIconFromText(std::wstring_view text) {
         case L'\uF2A8':  // Full bell, Do Not Disturb
             return SystemTrayIconIdent::kBellFull;
 
+        // Language supplementary icons.
+        // Found by installing all the built-in input methods from:
+        // https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-language-pack-default-values?view=windows-11#input-method-editors
+        // and identify the icon code in the fonts Segoe Fluent and AXPIcons.ttf.
+        // https://learn.microsoft.com/en-us/windows/apps/design/style/segoe-fluent-icons-font
+        // %SystemRoot%\SystemApps\MicrosoftWindows.Client.Core_cw5n1h2txyewy\SystemTray\Assets\AXPIcons.ttf
         case L'\uE4D7':  // (Maybe) English Private mode
         case L'\uE4D8':  // (Maybe) Chinese Private mode
         case L'\uE5BF':  // (Maybe) English mode locked
@@ -546,6 +552,13 @@ void ApplyNonActivatableStackIconViewStyle(
     }
 
     if (!child) {
+        // Some input methods use LanguageImageIconContent/ImageIconContent instead of
+        // LanguageTextIconContent/TextIconContent with icon fonts. If the language bar
+        // is hidden and the user switches from a "text" input method to a "image" input
+        // method, the invisible element will not be populated with the new type of icon
+        // content but become empty instead. Then the icon will be permanently hidden 
+        // even after disabling the mod. This code forces the empty element to become 
+        // visible and populated, fixing this issue.
         if (Media::VisualTreeHelper::GetChildrenCount(notifyIconViewElement) == 0) {
             notifyIconViewElement.Visibility(Visibility::Visible);
         }


### PR DESCRIPTION
Closes https://github.com/ramensoftware/windhawk-mods/issues/1489

It turns out more complicated than I thought. 

- Besides the language's supplementary icon, there are other icons in NonActivatableStack, such as the virtual keyboard. They can be configured in Windows settings, so I'd like to exclude them and only control the language supplementary icon.
	- I tried all the input methods in [Windows doc](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-language-pack-default-values?view=windows-11#input-method-editors) and found the relevant icon codes in [Segoe Fluent](https://learn.microsoft.com/en-us/windows/apps/design/style/segoe-fluent-icons-font) and AXPIcons.ttf. The icon's text are now filtered by IdentifySystemTrayIconFromText.
	- If there are any new icons in future updates, the code list need to be updated. 
- Some input methods (maybe legacy or third-party ones) use ImageIconContent/LanguageImageIconContent instead of TextIconContent/LanguageTextIconContent with icon fonts. Now these elements in NonActivatableStack are identified as language icons. 
- When switching from "text" input methods to "icon" input methods, as the element tag changes, the icon becomes permanently hidden. In UWPSpy I found that the element is not populated (becomes empty), so I add a clause to re-show empty elements to fix this issue. 

Please tell me if there is any problem. Thank you!