### PR TITLE
taskbar-grouping: ignore pinned when placing ungrouped items together

### DIFF
--- a/mods/taskbar-grouping.wh.cpp
+++ b/mods/taskbar-grouping.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-grouping
 // @name            Disable grouping on the taskbar
 // @description     Causes a separate button to be created on the taskbar for each new window
-// @version         1.3.9
+// @version         1.3.10
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -63,6 +63,11 @@ or a similar tool), enable the relevant option in the mod's settings.
   $name: Place ungrouped items together
   $description: >-
     Place each newly opened item next to existing items it would group with.
+- ignorePinnedItemsWhenPlacingUngroupedItemsTogether: false
+  $name: Ignore pinned items when placing ungrouped items together
+  $description: >-
+    If this and "Place ungrouped items together" is enabled above,
+    pinned items will be skipped when searching for the place of the new item
 - useWindowIcons: false
   $name: Use window icons
   $description: >-
@@ -149,6 +154,7 @@ enum class GroupingMode {
 struct {
     PinnedItemsMode pinnedItemsMode;
     bool placeUngroupedItemsTogether;
+    bool ignorePinnedItemsWhenPlacingUngroupedItemsTogether;
     bool useWindowIcons;
     std::unordered_set<std::wstring> excludedProgramItems;
     std::vector<std::wstring> customGroupNames;
@@ -942,6 +948,13 @@ int WINAPI DPA_InsertPtr_Hook(HDPA hdpa, int i, void* p) {
         PVOID taskGroupIter = CTaskBtnGroup_GetGroup_Original(taskBtnGroupIter);
         if (!taskGroupIter) {
             continue;
+        }
+
+        if (g_settings.ignorePinnedItemsWhenPlacingUngroupedItemsTogether) {
+            bool pinned = CTaskGroup_GetFlags_Original(taskGroupIter) & 1;
+            if (pinned) {
+                continue;
+            }
         }
 
         g_compareStringOrdinalHookThreadId = GetCurrentThreadId();
@@ -1808,6 +1821,8 @@ void LoadSettings() {
 
     g_settings.placeUngroupedItemsTogether =
         Wh_GetIntSetting(L"placeUngroupedItemsTogether");
+    g_settings.ignorePinnedItemsWhenPlacingUngroupedItemsTogether =
+            Wh_GetIntSetting(L"ignorePinnedItemsWhenPlacingUngroupedItemsTogether");
     g_settings.useWindowIcons = Wh_GetIntSetting(L"useWindowIcons");
 
     g_settings.excludedProgramItems.clear();


### PR DESCRIPTION
It's a bit of a convoluted switch/feature, it may not have a place on the main branch, please feel free to close it.  
(Just opening this in case someone finds it useful / can improve it / can recommend me a plugin or setting that can already do this.)

The goal is to add an option to leave the pinned items alone when placing new items, while still grouping non-pinned items together.   
(So I can arrange the pinned items on the taskbar to the left, and they are left in their place. They are not going to be  disturbed, reordered, mixed by the opened items, similar to how it worked in older Windows OSes.)