### PR TITLE
[Taskbar Clock Customization] Make network metrics unit, amount of decimals and unit display configurable

### DIFF
--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -156,6 +156,21 @@ styles, such as the font color and size.
   $description: >-
     The update interval, in seconds, of the system performance metrics such as
     CPU and RAM usage.
+- NetworkMetricsUnit: mbs
+  $name: Network metrics unit
+  $description: >-
+    The unit to use for displaying the upload/download transfer rate.
+  $options:
+  - mbs: MB/s
+  - mbits: MBit/s
+- NetworkMetricsShowUnit: true
+  $name: Network metrics show unit
+  $description: Show the unit next to the upload/download transfer rate.
+- NetworkMetricsFixedDecimals: -1
+  $name: Network metrics fixed decimal places
+  $description: >-
+    Always use this amount of decimal places for the upload/download transfer rate
+    (-1 means auto/same width).
 - WebContentWeatherLocation: ""
   $name: Weather location
   $description: >-
@@ -417,6 +432,11 @@ enum class ContentMode {
     xmlHtml,
 };
 
+enum class NetworkMetricsUnits {
+    mbs,
+    mbits,
+};
+
 struct WebContentsSettings {
     StringSetting url;
     StringSetting blockStart;
@@ -454,6 +474,9 @@ struct {
     int maxWidth;
     int textSpacing;
     int dataCollectionUpdateInterval;
+    NetworkMetricsUnits networkMetricsUnit;
+    bool networkMetricsShowUnit;
+    int networkMetricsFixedDecimals;
     StringSetting webContentWeatherLocation;
     StringSetting webContentWeatherFormat;
     WebContentWeatherUnits webContentWeatherUnits;
@@ -1917,24 +1940,46 @@ std::wstring FormatLocaleNum(double val, unsigned int digitsAfterDecimal) {
 }
 
 void FormatTransferSpeed(double val, PWSTR buffer, size_t bufferSize) {
-    double valMb = val / (1024 * 1024);
+    double valUnit;
+    PCWSTR unit = L"";
 
-    // Keep identical width for <1000 values.
-    int digitsAfterDecimal = 0;
-    PCWSTR prefix = L"";
-    if (valMb < 10) {
-        digitsAfterDecimal = 2;
-    } else if (valMb < 100) {
-        digitsAfterDecimal = 1;
-    } else if (valMb < 1000) {
-        // Punctuation Space.
-        prefix = L"\u2008";
+    switch (g_settings.networkMetricsUnit) {
+        case NetworkMetricsUnits::mbs:
+            valUnit = val / (1024 * 1024);
+            unit = L" MB/s";
+            break;
+        case NetworkMetricsUnits::mbits:
+            valUnit = val * 8.0 / 1000000.0;
+            unit = L" MBit/s";
+            break;
     }
 
-    std::wstring valMbFormatted = FormatLocaleNum(valMb, digitsAfterDecimal);
+    if (!g_settings.networkMetricsShowUnit) {
+        unit = L"";
+    }
 
-    swprintf_s(buffer, bufferSize, L"%s%s MB/s", prefix,
-               valMbFormatted.c_str());
+    int digitsAfterDecimal = 0;
+    PCWSTR prefix = L"";
+
+    if (g_settings.networkMetricsFixedDecimals == -1) {
+        // Keep identical width for <1000 values.
+        if (valUnit < 10) {
+            digitsAfterDecimal = 2;
+        } else if (valUnit < 100) {
+            digitsAfterDecimal = 1;
+        } else if (valUnit < 1000) {
+            // Punctuation Space.
+            prefix = L"\u2008";
+        }
+    }
+    else {
+        digitsAfterDecimal = g_settings.networkMetricsFixedDecimals;
+    }
+
+    std::wstring valUnitFormatted = FormatLocaleNum(valUnit, digitsAfterDecimal);
+
+    swprintf_s(buffer, bufferSize, L"%s%s%s", prefix,
+               valUnitFormatted.c_str(), unit);
 }
 
 void FormatPercentValue(int val, PWSTR buffer, size_t bufferSize) {
@@ -3597,6 +3642,17 @@ void LoadSettings() {
     g_settings.textSpacing = Wh_GetIntSetting(L"TextSpacing");
     g_settings.dataCollectionUpdateInterval =
         Wh_GetIntSetting(L"DataCollectionUpdateInterval");
+    
+    g_settings.networkMetricsUnit = NetworkMetricsUnits::mbs;
+    StringSetting networkMetricsUnit =
+        StringSetting::make(L"NetworkMetricsUnit");
+    if (wcscmp(networkMetricsUnit, L"mbits") == 0) {
+        g_settings.networkMetricsUnit = NetworkMetricsUnits::mbits;
+    }
+
+    g_settings.networkMetricsShowUnit = Wh_GetIntSetting(L"NetworkMetricsShowUnit");
+    g_settings.networkMetricsFixedDecimals = Wh_GetIntSetting(L"NetworkMetricsFixedDecimals");
+
     g_settings.webContentWeatherLocation =
         StringSetting::make(L"WebContentWeatherLocation");
     g_settings.webContentWeatherFormat =


### PR DESCRIPTION
_(The same as https://github.com/ramensoftware/windhawk-mods/pull/2314.)_

In reference to https://github.com/ramensoftware/windhawk-mods/commit/7068e6957690dc8bb1c1d1449041593fc34ff51e, https://github.com/ramensoftware/windhawk-mods/issues/2279 and https://github.com/ramensoftware/windhawk-mods/issues/2278#issuecomment-3172680480:

The network metrics (upload/download transfer speed) are currently fixed to MB/s and a "constant width"-amount of decimal places.

For me personally MBit/s and always 2 decimal places and not showing the unit itself (since I know I want to see MBit/s) still makes more sense (probably due to that here in Germany that's the common unit in which internet speed is advertised). Of course this is up to very personal preference, so I added 3 new settings to make all that configurable:

<img width="695" height="341" alt="grafik" src="https://github.com/user-attachments/assets/ea397af5-74bd-41d8-abca-a34181674606" />

I think the setting descriptions should be self-explanatory.

The setting defaults are the current state, so no changed behavior on update or for new users of this mod.