### PR TITLE
Add inclusion/exclusion list for "Use window icons"

### DIFF
--- a/mods/taskbar-grouping.wh.cpp
+++ b/mods/taskbar-grouping.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-grouping
 // @name            Disable grouping on the taskbar
 // @description     Causes a separate button to be created on the taskbar for each new window
-// @version         1.3.10
+// @version         1.3.11
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -75,6 +75,12 @@ or a similar tool), enable the relevant option in the mod's settings.
     open folder window - with application icons, the icon on the taskbar is
     always the icon of Explorer, while with window icons, the icon changes
     depending on the open folder.
+- windowIconsPrograms: [example1.exe]
+  $name: Window icon programs
+  $description: >-
+    Each entry is a name, path, or application ID that affects window icon behavior.
+    When "Use window icons" is enabled, these programs will be excluded. When "Use window icons" is disabled, only these 
+    programs will use window icons.
 - customGroups:
   - - name: Group 1
       $name: Group name
@@ -160,12 +166,15 @@ struct {
     PinnedItemsMode pinnedItemsMode;
     PlaceUngroupedItemsTogetherMode placeUngroupedItemsTogether;
     bool useWindowIcons;
+    std::unordered_set<std::wstring> windowIconProgramItems;
     std::unordered_set<std::wstring> excludedProgramItems;
     std::vector<std::wstring> customGroupNames;
     std::unordered_map<std::wstring, int> customGroupProgramItems;
     GroupingMode groupingMode;
     bool oldTaskbarOnWin11;
 } g_settings;
+
+std::unordered_map<std::wstring, int> g_appIdsUsingWindowIcons;
 
 enum class WinVersion {
     Unsupported,
@@ -423,6 +432,27 @@ void ProcessResolvedWindow(PVOID pThis, RESOLVEDWINDOW* resolvedWindow) {
         }
     }
 
+    bool useWindowIcon = g_settings.useWindowIcons;
+    if (!g_settings.windowIconProgramItems.empty()) {
+        bool inList = false;
+
+        if (g_settings.windowIconProgramItems.contains(resolvedAppIdStrUpper)) {
+            inList = true;
+        } else if (resolvedWindowProcessPathLen > 0 &&
+                g_settings.windowIconProgramItems.contains(resolvedWindowProcessPathUpper)) {
+            inList = true;
+        } else if (programFileNameUpper &&
+                g_settings.windowIconProgramItems.contains(programFileNameUpper)) {
+            inList = true;
+        }
+
+        useWindowIcon = (g_settings.useWindowIcons != inList);
+    }
+
+    if (useWindowIcon) {
+        g_appIdsUsingWindowIcons[resolvedAppIdStrUpper]++;
+    }
+
     if (!customGroup) {
         winrt::com_ptr<IUnknown> taskGroupMatched;
         winrt::com_ptr<IUnknown> taskItemMatched;
@@ -670,8 +700,22 @@ const ITEMIDLIST* WINAPI CTaskGroup_GetShortcutIDList_Hook(PVOID pThis) {
             return nullptr;
         }
 
-        if (g_settings.useWindowIcons) {
-            return nullptr;
+        PCWSTR appId = CTaskGroup_GetAppID_Original(pThis);
+        if (appId && *appId) {
+            WCHAR appIdClean[MAX_PATH];
+            wcscpy_s(appIdClean, appId);
+
+            RemoveAppIdSuffix(appIdClean, appId);
+
+            WCHAR appIdUpper[MAX_PATH];
+            int len = wcslen(appIdClean);
+            LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_UPPERCASE,
+                          appIdClean, len + 1,
+                          appIdUpper, len + 1, nullptr, nullptr, 0);
+
+            if (g_appIdsUsingWindowIcons.count(appIdUpper)) {
+                return nullptr;
+            }
         }
 
         if (taskGroupWithoutSuffix) {
@@ -1152,6 +1196,26 @@ LONG_PTR OnTaskDestroyed(std::function<LONG_PTR()> original,
     // instances on other monitors or virtual desktops.
     if (!taskItem) {
         return original();
+    }
+
+    PCWSTR appId = CTaskGroup_GetAppID_Original(taskGroup);
+    if (appId) {
+        WCHAR appIdClean[MAX_PATH];
+        wcscpy_s(appIdClean, appId);
+        RemoveAppIdSuffix(appIdClean, appId);
+        
+        WCHAR appIdUpper[MAX_PATH];
+        int len = wcslen(appIdClean);
+        LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_UPPERCASE,
+                      appIdClean, len + 1,
+                      appIdUpper, len + 1, nullptr, nullptr, 0);
+        
+        auto it = g_appIdsUsingWindowIcons.find(appIdUpper);
+        if (it != g_appIdsUsingWindowIcons.end()) {
+            it->second--;
+            
+            if (it->second <= 0) g_appIdsUsingWindowIcons.erase(it);
+        }
     }
 
     bool isPrimaryTaskbar =
@@ -1841,6 +1905,28 @@ void LoadSettings() {
     Wh_FreeStringSetting(placeUngroupedItemsTogetherMode);
 
     g_settings.useWindowIcons = Wh_GetIntSetting(L"useWindowIcons");
+
+    g_settings.windowIconProgramItems.clear();
+
+    for (int i = 0;; i++) {
+        PCWSTR program = Wh_GetStringSetting(L"windowIconsPrograms[%d]", i);
+
+        bool hasProgram = *program;
+        if (hasProgram) {
+            std::wstring programUpper = program;
+            LCMapStringEx(
+                LOCALE_NAME_USER_DEFAULT, LCMAP_UPPERCASE, &programUpper[0],
+                static_cast<int>(programUpper.length()), &programUpper[0],
+                static_cast<int>(programUpper.length()), nullptr, nullptr, 0);
+
+            g_settings.windowIconProgramItems.insert(std::move(programUpper));
+        }
+
+        Wh_FreeStringSetting(program);
+        if (!hasProgram) {
+            break;
+        }
+    }
 
     g_settings.excludedProgramItems.clear();
 

--- a/mods/taskbar-grouping.wh.cpp
+++ b/mods/taskbar-grouping.wh.cpp
@@ -174,7 +174,14 @@ struct {
     bool oldTaskbarOnWin11;
 } g_settings;
 
-std::unordered_map<std::wstring, int> g_appIdsUsingWindowIcons;
+struct AppIdIconInfo {
+    int count;
+    std::wstring resolvedAppIdStrUpper;
+    std::wstring resolvedWindowProcessPathUpper;
+    std::wstring programFileNameUpper;
+};
+
+std::unordered_map<std::wstring, AppIdIconInfo> g_appIdsUsingWindowIcons;
 
 enum class WinVersion {
     Unsupported,
@@ -450,7 +457,30 @@ void ProcessResolvedWindow(PVOID pThis, RESOLVEDWINDOW* resolvedWindow) {
     }
 
     if (useWindowIcon) {
-        g_appIdsUsingWindowIcons[resolvedAppIdStrUpper]++;
+        std::wstring cacheKey;
+
+        if (customGroup) {
+            WCHAR customGroupId[MAX_PATH];
+            swprintf(customGroupId, L"%s%d", kCustomGroupPrefix, customGroup);
+            
+            WCHAR customGroupIdUpper[MAX_PATH];
+            int len = (int)wcslen(customGroupId);
+            LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_UPPERCASE,
+                          customGroupId, len + 1,
+                          customGroupIdUpper, len + 1, nullptr, nullptr, 0);
+            
+            cacheKey = customGroupIdUpper;
+        } else {
+            cacheKey = resolvedAppIdStrUpper;
+        }
+
+        auto& info = g_appIdsUsingWindowIcons[cacheKey];
+        info.count++;
+        if (info.count == 1) {
+            info.resolvedAppIdStrUpper = resolvedAppIdStrUpper;
+            info.resolvedWindowProcessPathUpper = resolvedWindowProcessPathLen > 0 ? resolvedWindowProcessPathUpper : L"";
+            info.programFileNameUpper = programFileNameUpper ? programFileNameUpper : L"";
+        }
     }
 
     if (!customGroup) {
@@ -1212,9 +1242,10 @@ LONG_PTR OnTaskDestroyed(std::function<LONG_PTR()> original,
         
         auto it = g_appIdsUsingWindowIcons.find(appIdUpper);
         if (it != g_appIdsUsingWindowIcons.end()) {
-            it->second--;
-            
-            if (it->second <= 0) g_appIdsUsingWindowIcons.erase(it);
+            it->second.count--;
+            if (it->second.count <= 0) {
+                g_appIdsUsingWindowIcons.erase(it);
+            }
         }
     }
 
@@ -1927,6 +1958,24 @@ void LoadSettings() {
             break;
         }
     }
+
+    std::erase_if(g_appIdsUsingWindowIcons,
+        [](const auto& pair) {
+            const auto& info = pair.second;
+            bool useWindowIcon = g_settings.useWindowIcons;
+
+            if (!g_settings.windowIconProgramItems.empty()) {
+                bool inList = g_settings.windowIconProgramItems.contains(info.resolvedAppIdStrUpper) ||
+                            (!info.resolvedWindowProcessPathUpper.empty() &&
+                            g_settings.windowIconProgramItems.contains(info.resolvedWindowProcessPathUpper)) ||
+                            (!info.programFileNameUpper.empty() &&
+                            g_settings.windowIconProgramItems.contains(info.programFileNameUpper));
+
+                useWindowIcon = (g_settings.useWindowIcons != inList);
+            }
+
+            return !useWindowIcon;
+    });
 
     g_settings.excludedProgramItems.clear();
 


### PR DESCRIPTION
This PR adds an option to partially enable/disable "Use window icons" for specific programs.

- When "Use window icons" is enabled, listed programs are excluded
- When "Use window icons" is disabled, only listed programs use window icons

Related ramensoftware/windhawk-mods#3432