### PR TITLE
[taskbar-clock-customization] new values

### DIFF
--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-clock-customization
 // @name            Taskbar Clock Customization
 // @description     Custom date/time format, news feed, weather, performance metrics (upload/download speed, CPU, RAM, GPU, battery), media player info, custom fonts and colors, and more
-// @version         1.7.5
+// @version         1.7.4
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -195,14 +195,7 @@ styles, such as the font color and size.
   $description: >-
     Set to zero for the default system value. A negative value can be used for
     negative spacing.
-- GpuAdapterName: ""
-  $name: GPU adapter name
-  $description: >-
-    The GPU adapter to use for GPU usage and VRAM metrics. Leave empty to
-    auto-detect (uses the adapter with the most dedicated VRAM). Partial match is supported.
-    To list adapters, run:
 
-    wmic path win32_videocontroller get Name
 - DataCollection:
   - NetworkMetricsFormat: mbs
     $name: Network metrics format
@@ -244,7 +237,14 @@ styles, such as the font color and size.
       sum all adapters. Partial match is supported. To list adapters, run:
 
       typeperf -qx "Network Interface"
+  - GpuAdapterName: ""
+    $name: GPU adapter name
+    $description: >-
+      The GPU adapter to use for GPU usage and VRAM metrics. Leave empty to
+      auto-detect (uses the adapter with the most dedicated VRAM). Partial match is supported.
+      To list adapters, run:
 
+      wmic path win32_videocontroller get Name
   $name: System performance metrics
 - MediaPlayer:
   - IgnoredPlayers: [""]

--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -85,6 +85,9 @@ patterns can be used:
   * `%ram%` - RAM usage.
   * `%ram_used%` - Used RAM amount in GB.
   * `%ram_total%` - Total RAM amount in GB.
+  * `%ram_commited%` - Committed RAM usage.
+  * `%ram_commited_used%` - Used committed RAM amount in GB.
+  * `%ram_commited_total%` - Total committed RAM amount in GB.
   * `%gpu%` - GPU usage.
   * `%vram%` - VRAM usage as a percentage of total dedicated VRAM.
   * `%vram_used%` - Used dedicated VRAM amount in GB.
@@ -682,6 +685,9 @@ FormattedString<FORMATTED_BUFFER_SIZE> g_cpuFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_ramFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_ramUsedFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_ramTotalFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommitedFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommitedUsedFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommitedTotalFormatted;
 MEMORYSTATUSEX g_ramStatus;
 bool g_ramStatusValid = false;
 DWORD g_ramLastFormatIndex = 0xFFFFFFFF;
@@ -3364,6 +3370,53 @@ PCWSTR GetRamTotalFormatted() {
         });
 }
 
+PCWSTR GetRamCommitedFormatted() {
+    return GetMetricFormatted(
+        g_ramCommitedFormatted, [](PWSTR buffer, size_t bufferSize) {
+            RamSampleIfNeeded();
+            if (!g_ramStatusValid || g_ramStatus.ullTotalPageFile == 0) {
+                return false;
+            }
+            int committed = static_cast<int>(
+                ((g_ramStatus.ullTotalPageFile - g_ramStatus.ullAvailPageFile) *
+                 100) /
+                g_ramStatus.ullTotalPageFile);
+            // Cap to 99 to keep identical width in all cases.
+            int maxVal = 99;
+            FormatPercentValue(committed, buffer, bufferSize, maxVal);
+            return true;
+        });
+}
+
+PCWSTR GetRamCommitedUsedFormatted() {
+    return GetMetricFormatted(
+        g_ramCommitedUsedFormatted, [](PWSTR buffer, size_t bufferSize) {
+            RamSampleIfNeeded();
+            if (!g_ramStatusValid) {
+                return false;
+            }
+            double usedGb = (double)(g_ramStatus.ullTotalPageFile -
+                                     g_ramStatus.ullAvailPageFile) /
+                            (1024.0 * 1024.0 * 1024.0);
+            swprintf_s(buffer, bufferSize, L"%.1f", usedGb);
+            return true;
+        });
+}
+
+PCWSTR GetRamCommitedTotalFormatted() {
+    return GetMetricFormatted(
+        g_ramCommitedTotalFormatted, [](PWSTR buffer, size_t bufferSize) {
+            RamSampleIfNeeded();
+            if (!g_ramStatusValid) {
+                return false;
+            }
+            double totalGb =
+                (double)g_ramStatus.ullTotalPageFile / (1024.0 * 1024.0 * 1024.0);
+            swprintf_s(buffer, bufferSize, L"%.1f", totalGb);
+            return true;
+        });
+}
+
 PCWSTR GetGpuFormatted() {
     DataCollectionSampleIfNeeded();
     return GetMetricFormatted(g_gpuFormatted, [](PWSTR buffer,
@@ -3682,6 +3735,9 @@ size_t ResolveFormatToken(
         {L"%ram%"sv, GetRamFormatted},
         {L"%ram_used%"sv, GetRamUsedFormatted},
         {L"%ram_total%"sv, GetRamTotalFormatted},
+        {L"%ram_commited%"sv, GetRamCommitedFormatted},
+        {L"%ram_commited_used%"sv, GetRamCommitedUsedFormatted},
+        {L"%ram_commited_total%"sv, GetRamCommitedTotalFormatted},
         {L"%gpu%"sv, GetGpuFormatted},
         {L"%vram%"sv, GetVramFormatted},
         {L"%vram_used%"sv, GetVramUsedFormatted},

--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-clock-customization
 // @name            Taskbar Clock Customization
 // @description     Custom date/time format, news feed, weather, performance metrics (upload/download speed, CPU, RAM, GPU, battery), media player info, custom fonts and colors, and more
-// @version         1.7.4
+// @version         1.7.5
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -83,7 +83,12 @@ patterns can be used:
   * `%disk_total%` - combined disk read and write speed.
   * `%cpu%` - CPU usage.
   * `%ram%` - RAM usage.
+  * `%ram_used%` - Used RAM amount in GB.
+  * `%ram_total%` - Total RAM amount in GB.
   * `%gpu%` - GPU usage.
+  * `%vram%` - VRAM usage as a percentage of total dedicated VRAM.
+  * `%vram_used%` - Used dedicated VRAM amount in GB.
+  * `%vram_total%` - Total dedicated VRAM amount in GB.
   * `%cpu_temp%` - CPU temperature in °C (average of all ACPI thermal zones).
   * `%cpu_temp_f%` - CPU temperature in °F (average of all ACPI thermal zones).
   * `%battery%` - battery level percentage.
@@ -184,6 +189,15 @@ styles, such as the font color and size.
   $description: >-
     Set to zero for the default system value. A negative value can be used for
     negative spacing.
+- GpuAdapterName: ""
+  $name: GPU adapter name
+  $description: >-
+    The GPU adapter to use for GPU usage and VRAM metrics. Leave empty to
+    auto-detect (uses the adapter with the most dedicated VRAM for VRAM
+    metrics, sums all adapters for GPU usage). Partial match is supported.
+    To list adapters, run:
+
+    wmic path win32_videocontroller get Name
 - DataCollection:
   - NetworkMetricsFormat: mbs
     $name: Network metrics format
@@ -225,13 +239,7 @@ styles, such as the font color and size.
       sum all adapters. Partial match is supported. To list adapters, run:
 
       typeperf -qx "Network Interface"
-  - GpuAdapterName: ""
-    $name: GPU adapter name
-    $description: >-
-      The GPU adapter to use for GPU usage metrics. Leave empty to sum all
-      adapters. Partial match is supported. To list adapters, run:
 
-      wmic path win32_videocontroller get Name
   $name: System performance metrics
 - MediaPlayer:
   - IgnoredPlayers: [""]
@@ -506,6 +514,9 @@ using namespace winrt::Windows::UI::Xaml;
 #define URL_ESCAPE_ASCII_URI_COMPONENT 0x00080000
 #endif
 
+// fd
+DWORD GetDataCollectionFormatIndex();
+
 enum class TooltipLineMode {
     append,
     replace,
@@ -666,7 +677,15 @@ FormattedString<FORMATTED_BUFFER_SIZE> g_diskWriteSpeedFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_diskTotalSpeedFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_cpuFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_ramFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_ramUsedFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_ramTotalFormatted;
+MEMORYSTATUSEX g_ramStatus;
+bool g_ramStatusValid = false;
+DWORD g_ramLastFormatIndex = 0xFFFFFFFF;
 FormattedString<FORMATTED_BUFFER_SIZE> g_gpuFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_vramFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_vramUsedFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_vramTotalFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_cpuTempFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_cpuTempFFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_batteryFormatted;
@@ -1857,6 +1876,9 @@ enum class MetricType {
     kDiskWriteSpeed,
     kCpu,
     kGpuUsage,
+    kVramUsage,
+    kVramUsed,
+    kVramTotal,
     kCpuTemp,
 
     kCount,
@@ -1882,6 +1904,9 @@ class QueryDataCollectionSession {
     bool SampleData();
     std::optional<double> QueryData(MetricType type);
     std::optional<double> QueryDataAvg(MetricType type);
+    std::optional<double> QueryVramUsage();
+    std::optional<double> QueryVramUsed();
+    std::optional<double> QueryVramTotal();
 
    private:
     struct QueryDataResult {
@@ -1904,6 +1929,7 @@ class QueryDataCollectionSession {
         const std::vector<std::wstring>& paths,
         PCWSTR gpu_name,
         bool quiet);
+    static SIZE_T GetDxgiDedicatedVideoMemory(PCWSTR gpu_name);
 
     std::vector<std::wstring> ExpandAndFilterWildcardPaths(MetricType type,
                                                            PCWSTR counter_path,
@@ -1913,7 +1939,8 @@ class QueryDataCollectionSession {
 
         // Filter paths by adapter name if specified.
         if (adapter_name && *adapter_name && !paths.empty()) {
-            if (type == MetricType::kGpuUsage) {
+            if (type == MetricType::kGpuUsage ||
+                type == MetricType::kVramUsed) {
                 paths = FilterGpuPathsByAdapterName(paths, adapter_name, quiet);
             } else {
                 paths =
@@ -1934,6 +1961,10 @@ class QueryDataCollectionSession {
         PCWSTR wildcard_path = nullptr;
         PCWSTR adapter_name = nullptr;
     };
+
+    // Cached total VRAM from DXGI (queried once).
+    SIZE_T vram_total_bytes_ = 0;
+    bool vram_total_queried_ = false;
 
     PDH_HQUERY query_;
     MetricData metrics_[static_cast<int>(MetricType::kCount)];
@@ -1969,6 +2000,15 @@ bool QueryDataCollectionSession::AddMetric(MetricType type) {
             counter_path = L"\\GPU Engine(*)\\Utilization Percentage";
             is_wildcard = true;
             adapter_name = g_settings.dataCollection.gpuAdapterName;
+            break;
+        case MetricType::kVramUsed:
+        case MetricType::kVramUsage:  // computed from kVramUsed + DXGI total
+            counter_path = L"\\GPU Adapter Memory(*)\\Dedicated Usage";
+            is_wildcard = true;
+            adapter_name = g_settings.dataCollection.gpuAdapterName;
+            break;
+        case MetricType::kVramTotal:
+            // Total VRAM queried from DXGI, not a PDH counter.
             break;
         case MetricType::kCpuTemp:
             counter_path = L"\\Thermal Zone Information(*)\\Temperature";
@@ -2112,11 +2152,87 @@ QueryDataCollectionSession::QueryDataWithCount(MetricType type) {
 }
 
 std::optional<double> QueryDataCollectionSession::QueryData(MetricType type) {
+    if (type == MetricType::kVramUsage) {
+        return QueryVramUsage();
+    }
+    if (type == MetricType::kVramUsed) {
+        return QueryVramUsed();
+    }
+    if (type == MetricType::kVramTotal) {
+        return QueryVramTotal();
+    }
     auto result = QueryDataWithCount(type);
     if (!result) {
         return std::nullopt;
     }
     return result->sum;
+}
+
+std::optional<double> QueryDataCollectionSession::QueryVramUsage() {
+    auto used = QueryVramUsed();
+    auto total = QueryVramTotal();
+    if (used && total && *total > 0) {
+        return (*used / *total) * 100.0;
+    }
+    return std::nullopt;
+}
+
+std::optional<double> QueryDataCollectionSession::QueryVramUsed() {
+    auto result = QueryDataWithCount(MetricType::kVramUsed);
+    if (result) {
+        return result->sum / (1024.0 * 1024.0 * 1024.0);
+    }
+    return std::nullopt;
+}
+
+std::optional<double> QueryDataCollectionSession::QueryVramTotal() {
+    if (!vram_total_queried_) {
+        vram_total_bytes_ = GetDxgiDedicatedVideoMemory(
+            g_settings.dataCollection.gpuAdapterName);
+        vram_total_queried_ = true;
+    }
+
+    if (vram_total_bytes_ > 0) {
+        return (double)vram_total_bytes_ / (1024.0 * 1024.0 * 1024.0);
+    }
+
+    return std::nullopt;
+}
+
+SIZE_T QueryDataCollectionSession::GetDxgiDedicatedVideoMemory(
+    PCWSTR gpu_name) {
+    winrt::com_ptr<IDXGIFactory> factory;
+    if (FAILED(CreateDXGIFactory(IID_PPV_ARGS(factory.put())))) {
+        return 0;
+    }
+
+    SIZE_T best_vram = 0;
+    for (UINT i = 0;; i++) {
+        winrt::com_ptr<IDXGIAdapter> adapter;
+        if (factory->EnumAdapters(i, adapter.put()) == DXGI_ERROR_NOT_FOUND) {
+            break;
+        }
+
+        DXGI_ADAPTER_DESC desc{};
+        if (FAILED(adapter->GetDesc(&desc))) {
+            continue;
+        }
+
+        // If a name is specified, check for a match.
+        if (gpu_name && *gpu_name) {
+            if (wcsstr(desc.Description, gpu_name)) {
+                return desc.DedicatedVideoMemory;
+            }
+            continue;
+        }
+
+        // If no name is specified, pick the adapter with the most VRAM.
+        if (desc.DedicatedVideoMemory > best_vram) {
+            best_vram = desc.DedicatedVideoMemory;
+        }
+    }
+
+    return best_vram;
 }
 
 std::optional<double> QueryDataCollectionSession::QueryDataAvg(
@@ -2629,6 +2745,12 @@ void DataCollectionSessionInit() {
         IsStrInDateTimePatternSettings(L"%cpu%");
     metrics[static_cast<int>(MetricType::kGpuUsage)] =
         IsStrInDateTimePatternSettings(L"%gpu%");
+    metrics[static_cast<int>(MetricType::kVramUsage)] =
+        IsStrInDateTimePatternSettings(L"%vram%");
+    metrics[static_cast<int>(MetricType::kVramUsed)] =
+        IsStrInDateTimePatternSettings(L"%vram_used%");
+    metrics[static_cast<int>(MetricType::kVramTotal)] =
+        IsStrInDateTimePatternSettings(L"%vram_total%");
     metrics[static_cast<int>(MetricType::kCpuTemp)] =
         IsStrInDateTimePatternSettings(L"%cpu_temp%") ||
         IsStrInDateTimePatternSettings(L"%cpu_temp_f%");
@@ -2780,6 +2902,15 @@ void DataCollectionSampleIfNeeded() {
         }
 
         g_dataCollectionLastFormatIndex = dataCollectionFormatIndex;
+    }
+}
+
+void RamSampleIfNeeded() {
+    DWORD formatIndex = GetDataCollectionFormatIndex();
+    if (g_ramLastFormatIndex != formatIndex) {
+        g_ramStatus.dwLength = sizeof(g_ramStatus);
+        g_ramStatusValid = GlobalMemoryStatusEx(&g_ramStatus);
+        g_ramLastFormatIndex = formatIndex;
     }
 }
 
@@ -3082,15 +3213,43 @@ PCWSTR GetCpuFormatted() {
 PCWSTR GetRamFormatted() {
     return GetMetricFormatted(
         g_ramFormatted, [](PWSTR buffer, size_t bufferSize) {
-            MEMORYSTATUSEX status{
-                .dwLength = sizeof(status),
-            };
-            if (!GlobalMemoryStatusEx(&status)) {
+            RamSampleIfNeeded();
+            if (!g_ramStatusValid) {
                 return false;
             }
             // Cap to 99 to keep identical width in all cases.
             int maxVal = 99;
-            FormatPercentValue(status.dwMemoryLoad, buffer, bufferSize, maxVal);
+            FormatPercentValue(g_ramStatus.dwMemoryLoad, buffer, bufferSize,
+                               maxVal);
+            return true;
+        });
+}
+
+PCWSTR GetRamUsedFormatted() {
+    return GetMetricFormatted(
+        g_ramUsedFormatted, [](PWSTR buffer, size_t bufferSize) {
+            RamSampleIfNeeded();
+            if (!g_ramStatusValid) {
+                return false;
+            }
+            double usedGb =
+                (double)(g_ramStatus.ullTotalPhys - g_ramStatus.ullAvailPhys) /
+                (1024.0 * 1024.0 * 1024.0);
+            swprintf_s(buffer, bufferSize, L"%.1f", usedGb);
+            return true;
+        });
+}
+
+PCWSTR GetRamTotalFormatted() {
+    return GetMetricFormatted(
+        g_ramTotalFormatted, [](PWSTR buffer, size_t bufferSize) {
+            RamSampleIfNeeded();
+            if (!g_ramStatusValid) {
+                return false;
+            }
+            double totalGb =
+                (double)g_ramStatus.ullTotalPhys / (1024.0 * 1024.0 * 1024.0);
+            swprintf_s(buffer, bufferSize, L"%.1f", totalGb);
             return true;
         });
 }
@@ -3112,6 +3271,59 @@ PCWSTR GetGpuFormatted() {
         FormatPercentValue(static_cast<int>(*val), buffer, bufferSize, maxVal);
         return true;
     });
+}
+
+PCWSTR GetVramFormatted() {
+    DataCollectionSampleIfNeeded();
+    return GetMetricFormatted(g_vramFormatted, [](PWSTR buffer,
+                                                  size_t bufferSize) {
+        if (!g_dataCollectionSession) {
+            return false;
+        }
+        std::optional<double> val =
+            g_dataCollectionSession->QueryData(MetricType::kVramUsage);
+        if (!val) {
+            return false;
+        }
+        // Cap to 99 to keep identical width in all cases.
+        int maxVal = 99;
+        FormatPercentValue(static_cast<int>(*val), buffer, bufferSize, maxVal);
+        return true;
+    });
+}
+
+PCWSTR GetVramUsedFormatted() {
+    DataCollectionSampleIfNeeded();
+    return GetMetricFormatted(
+        g_vramUsedFormatted, [](PWSTR buffer, size_t bufferSize) {
+            if (!g_dataCollectionSession) {
+                return false;
+            }
+            std::optional<double> val =
+                g_dataCollectionSession->QueryData(MetricType::kVramUsed);
+            if (!val) {
+                return false;
+            }
+            swprintf_s(buffer, bufferSize, L"%.1f", *val);
+            return true;
+        });
+}
+
+PCWSTR GetVramTotalFormatted() {
+    DataCollectionSampleIfNeeded();
+    return GetMetricFormatted(
+        g_vramTotalFormatted, [](PWSTR buffer, size_t bufferSize) {
+            if (!g_dataCollectionSession) {
+                return false;
+            }
+            std::optional<double> val =
+                g_dataCollectionSession->QueryData(MetricType::kVramTotal);
+            if (!val) {
+                return false;
+            }
+            swprintf_s(buffer, bufferSize, L"%.1f", *val);
+            return true;
+        });
 }
 
 PCWSTR GetCpuTempFormatted() {
@@ -3305,7 +3517,12 @@ size_t ResolveFormatToken(
         {L"%disk_total%"sv, GetDiskTotalSpeedFormatted},
         {L"%cpu%"sv, GetCpuFormatted},
         {L"%ram%"sv, GetRamFormatted},
+        {L"%ram_used%"sv, GetRamUsedFormatted},
+        {L"%ram_total%"sv, GetRamTotalFormatted},
         {L"%gpu%"sv, GetGpuFormatted},
+        {L"%vram%"sv, GetVramFormatted},
+        {L"%vram_used%"sv, GetVramUsedFormatted},
+        {L"%vram_total%"sv, GetVramTotalFormatted},
         {L"%cpu_temp%"sv, GetCpuTempFormatted},
         {L"%cpu_temp_f%"sv, GetCpuTempFFormatted},
         {L"%battery%"sv, GetBatteryFormatted},

--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -684,9 +684,9 @@ FormattedString<FORMATTED_BUFFER_SIZE> g_cpuFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_ramFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_ramUsedFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_ramTotalFormatted;
-FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommitedFormatted;
-FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommitedUsedFormatted;
-FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommitedTotalFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommittedFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommittedUsedFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_ramCommittedTotalFormatted;
 MEMORYSTATUSEX g_ramStatus;
 bool g_ramStatusValid = false;
 DWORD g_ramLastFormatIndex = 0xFFFFFFFF;
@@ -3344,9 +3344,9 @@ PCWSTR GetRamTotalFormatted() {
         });
 }
 
-PCWSTR GetRamCommitedFormatted() {
+PCWSTR GetRamCommittedFormatted() {
     return GetMetricFormatted(
-        g_ramCommitedFormatted, [](PWSTR buffer, size_t bufferSize) {
+        g_ramCommittedFormatted, [](PWSTR buffer, size_t bufferSize) {
             RamSampleIfNeeded();
             if (!g_ramStatusValid || g_ramStatus.ullTotalPageFile == 0) {
                 return false;
@@ -3362,9 +3362,9 @@ PCWSTR GetRamCommitedFormatted() {
         });
 }
 
-PCWSTR GetRamCommitedUsedFormatted() {
+PCWSTR GetRamCommittedUsedFormatted() {
     return GetMetricFormatted(
-        g_ramCommitedUsedFormatted, [](PWSTR buffer, size_t bufferSize) {
+        g_ramCommittedUsedFormatted, [](PWSTR buffer, size_t bufferSize) {
             RamSampleIfNeeded();
             if (!g_ramStatusValid) {
                 return false;
@@ -3377,9 +3377,9 @@ PCWSTR GetRamCommitedUsedFormatted() {
         });
 }
 
-PCWSTR GetRamCommitedTotalFormatted() {
+PCWSTR GetRamCommittedTotalFormatted() {
     return GetMetricFormatted(
-        g_ramCommitedTotalFormatted, [](PWSTR buffer, size_t bufferSize) {
+        g_ramCommittedTotalFormatted, [](PWSTR buffer, size_t bufferSize) {
             RamSampleIfNeeded();
             if (!g_ramStatusValid) {
                 return false;
@@ -3709,9 +3709,9 @@ size_t ResolveFormatToken(
         {L"%ram%"sv, GetRamFormatted},
         {L"%ram_used%"sv, GetRamUsedFormatted},
         {L"%ram_total%"sv, GetRamTotalFormatted},
-        {L"%ram_committed%"sv, GetRamCommitedFormatted},
-        {L"%ram_committed_used%"sv, GetRamCommitedUsedFormatted},
-        {L"%ram_committed_total%"sv, GetRamCommitedTotalFormatted},
+        {L"%ram_committed%"sv, GetRamCommittedFormatted},
+        {L"%ram_committed_used%"sv, GetRamCommittedUsedFormatted},
+        {L"%ram_committed_total%"sv, GetRamCommittedTotalFormatted},
         {L"%gpu%"sv, GetGpuFormatted},
         {L"%vram%"sv, GetVramFormatted},
         {L"%vram_used%"sv, GetVramUsedFormatted},

--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -89,6 +89,9 @@ patterns can be used:
   * `%vram%` - VRAM usage as a percentage of total dedicated VRAM.
   * `%vram_used%` - Used dedicated VRAM amount in GB.
   * `%vram_total%` - Total dedicated VRAM amount in GB.
+  * `%vram_shared%` - Shared VRAM usage percentage (RAM borrowed by GPU).
+  * `%vram_shared_used%` - Used shared VRAM amount in GB.
+  * `%vram_shared_total%` - Total shared VRAM pool size in GB.
   * `%cpu_temp%` - CPU temperature in °C (average of all ACPI thermal zones).
   * `%cpu_temp_f%` - CPU temperature in °F (average of all ACPI thermal zones).
   * `%battery%` - battery level percentage.
@@ -686,6 +689,9 @@ FormattedString<FORMATTED_BUFFER_SIZE> g_gpuFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_vramFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_vramUsedFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_vramTotalFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_vramSharedFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_vramSharedUsedFormatted;
+FormattedString<FORMATTED_BUFFER_SIZE> g_vramSharedTotalFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_cpuTempFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_cpuTempFFormatted;
 FormattedString<FORMATTED_BUFFER_SIZE> g_batteryFormatted;
@@ -1879,6 +1885,9 @@ enum class MetricType {
     kVramUsage,
     kVramUsed,
     kVramTotal,
+    kVramSharedUsage,
+    kVramSharedUsed,
+    kVramSharedTotal,
     kCpuTemp,
 
     kCount,
@@ -1907,6 +1916,9 @@ class QueryDataCollectionSession {
     std::optional<double> QueryVramUsage();
     std::optional<double> QueryVramUsed();
     std::optional<double> QueryVramTotal();
+    std::optional<double> QueryVramSharedUsage();
+    std::optional<double> QueryVramSharedUsed();
+    std::optional<double> QueryVramSharedTotal();
 
    private:
     struct QueryDataResult {
@@ -1929,7 +1941,9 @@ class QueryDataCollectionSession {
         const std::vector<std::wstring>& paths,
         PCWSTR gpu_name,
         bool quiet);
-    static SIZE_T GetDxgiDedicatedVideoMemory(PCWSTR gpu_name);
+    static void GetDxgiVideoMemory(PCWSTR gpu_name,
+                                   SIZE_T* dedicated,
+                                   SIZE_T* shared);
 
     std::vector<std::wstring> ExpandAndFilterWildcardPaths(MetricType type,
                                                            PCWSTR counter_path,
@@ -1938,11 +1952,14 @@ class QueryDataCollectionSession {
         auto paths = ExpandEnglishWildcard(counter_path, quiet);
 
         // Filter paths by adapter name if specified.
-        if (adapter_name && *adapter_name && !paths.empty()) {
+        if (!paths.empty()) {
             if (type == MetricType::kGpuUsage ||
-                type == MetricType::kVramUsed) {
+                type == MetricType::kVramUsed ||
+                type == MetricType::kVramSharedUsed) {
+                // For GPU metrics, we always filter (to auto-select the best
+                // adapter if name is empty).
                 paths = FilterGpuPathsByAdapterName(paths, adapter_name, quiet);
-            } else {
+            } else if (adapter_name && *adapter_name) {
                 paths =
                     FilterNetworkPathsByAdapterName(paths, adapter_name, quiet);
             }
@@ -1962,8 +1979,9 @@ class QueryDataCollectionSession {
         PCWSTR adapter_name = nullptr;
     };
 
-    // Cached total VRAM from DXGI (queried once).
+    // Cached VRAM info from DXGI (queried once).
     SIZE_T vram_total_bytes_ = 0;
+    SIZE_T vram_shared_total_bytes_ = 0;
     bool vram_total_queried_ = false;
 
     PDH_HQUERY query_;
@@ -2002,14 +2020,20 @@ bool QueryDataCollectionSession::AddMetric(MetricType type) {
             adapter_name = g_settings.dataCollection.gpuAdapterName;
             break;
         case MetricType::kVramUsed:
-        case MetricType::kVramUsage:  // computed from kVramUsed + DXGI total
+        case MetricType::kVramUsage:
             counter_path = L"\\GPU Adapter Memory(*)\\Dedicated Usage";
             is_wildcard = true;
             adapter_name = g_settings.dataCollection.gpuAdapterName;
             break;
-        case MetricType::kVramTotal:
-            // Total VRAM queried from DXGI, not a PDH counter.
+        case MetricType::kVramSharedUsed:
+        case MetricType::kVramSharedUsage:
+            counter_path = L"\\GPU Adapter Memory(*)\\Shared Usage";
+            is_wildcard = true;
+            adapter_name = g_settings.dataCollection.gpuAdapterName;
             break;
+        case MetricType::kVramTotal:
+        case MetricType::kVramSharedTotal:
+            return true;  // Handled via DXGI
         case MetricType::kCpuTemp:
             counter_path = L"\\Thermal Zone Information(*)\\Temperature";
             is_wildcard = true;
@@ -2161,6 +2185,15 @@ std::optional<double> QueryDataCollectionSession::QueryData(MetricType type) {
     if (type == MetricType::kVramTotal) {
         return QueryVramTotal();
     }
+    if (type == MetricType::kVramSharedUsage) {
+        return QueryVramSharedUsage();
+    }
+    if (type == MetricType::kVramSharedUsed) {
+        return QueryVramSharedUsed();
+    }
+    if (type == MetricType::kVramSharedTotal) {
+        return QueryVramSharedTotal();
+    }
     auto result = QueryDataWithCount(type);
     if (!result) {
         return std::nullopt;
@@ -2187,8 +2220,8 @@ std::optional<double> QueryDataCollectionSession::QueryVramUsed() {
 
 std::optional<double> QueryDataCollectionSession::QueryVramTotal() {
     if (!vram_total_queried_) {
-        vram_total_bytes_ = GetDxgiDedicatedVideoMemory(
-            g_settings.dataCollection.gpuAdapterName);
+        GetDxgiVideoMemory(g_settings.dataCollection.gpuAdapterName,
+                           &vram_total_bytes_, &vram_shared_total_bytes_);
         vram_total_queried_ = true;
     }
 
@@ -2199,14 +2232,55 @@ std::optional<double> QueryDataCollectionSession::QueryVramTotal() {
     return std::nullopt;
 }
 
-SIZE_T QueryDataCollectionSession::GetDxgiDedicatedVideoMemory(
-    PCWSTR gpu_name) {
-    winrt::com_ptr<IDXGIFactory> factory;
-    if (FAILED(CreateDXGIFactory(IID_PPV_ARGS(factory.put())))) {
-        return 0;
+std::optional<double> QueryDataCollectionSession::QueryVramSharedUsage() {
+    auto used = QueryVramSharedUsed();
+    auto total = QueryVramSharedTotal();
+    if (used && total && *total > 0) {
+        return (*used / *total) * 100.0;
+    }
+    return std::nullopt;
+}
+
+std::optional<double> QueryDataCollectionSession::QueryVramSharedUsed() {
+    auto result = QueryDataWithCount(MetricType::kVramSharedUsed);
+    if (result) {
+        return result->sum / (1024.0 * 1024.0 * 1024.0);
+    }
+    return std::nullopt;
+}
+
+std::optional<double> QueryDataCollectionSession::QueryVramSharedTotal() {
+    if (!vram_total_queried_) {
+        GetDxgiVideoMemory(g_settings.dataCollection.gpuAdapterName,
+                           &vram_total_bytes_, &vram_shared_total_bytes_);
+        vram_total_queried_ = true;
     }
 
-    SIZE_T best_vram = 0;
+    if (vram_shared_total_bytes_ > 0) {
+        return (double)vram_shared_total_bytes_ / (1024.0 * 1024.0 * 1024.0);
+    }
+
+    return std::nullopt;
+}
+
+void QueryDataCollectionSession::GetDxgiVideoMemory(PCWSTR gpu_name,
+                                                    SIZE_T* dedicated,
+                                                    SIZE_T* shared) {
+    if (dedicated) {
+        *dedicated = 0;
+    }
+    if (shared) {
+        *shared = 0;
+    }
+
+    winrt::com_ptr<IDXGIFactory> factory;
+    if (FAILED(CreateDXGIFactory(IID_PPV_ARGS(factory.put())))) {
+        return;
+    }
+
+    DXGI_ADAPTER_DESC best_desc{};
+    bool found = false;
+
     for (UINT i = 0;; i++) {
         winrt::com_ptr<IDXGIAdapter> adapter;
         if (factory->EnumAdapters(i, adapter.put()) == DXGI_ERROR_NOT_FOUND) {
@@ -2221,18 +2295,28 @@ SIZE_T QueryDataCollectionSession::GetDxgiDedicatedVideoMemory(
         // If a name is specified, check for a match.
         if (gpu_name && *gpu_name) {
             if (wcsstr(desc.Description, gpu_name)) {
-                return desc.DedicatedVideoMemory;
+                best_desc = desc;
+                found = true;
+                break;
             }
-            continue;
-        }
-
-        // If no name is specified, pick the adapter with the most VRAM.
-        if (desc.DedicatedVideoMemory > best_vram) {
-            best_vram = desc.DedicatedVideoMemory;
+        } else {
+            // Auto-select the one with most dedicated VRAM.
+            if (!found ||
+                desc.DedicatedVideoMemory > best_desc.DedicatedVideoMemory) {
+                best_desc = desc;
+                found = true;
+            }
         }
     }
 
-    return best_vram;
+    if (found) {
+        if (dedicated) {
+            *dedicated = best_desc.DedicatedVideoMemory;
+        }
+        if (shared) {
+            *shared = best_desc.SharedSystemMemory;
+        }
+    }
 }
 
 std::optional<double> QueryDataCollectionSession::QueryDataAvg(
@@ -2385,12 +2469,16 @@ QueryDataCollectionSession::FilterNetworkPathsByAdapterName(
 }
 
 // Get the LUID for a GPU adapter by name using DXGI.
+// If gpu_name is empty, returns the LUID of the adapter with the most VRAM.
 std::wstring QueryDataCollectionSession::GetGpuLuidByName(PCWSTR gpu_name,
                                                           bool quiet) {
     winrt::com_ptr<IDXGIFactory> factory;
     if (FAILED(CreateDXGIFactory(IID_PPV_ARGS(factory.put())))) {
         return {};
     }
+
+    DXGI_ADAPTER_DESC best_desc{};
+    bool found = false;
 
     for (UINT i = 0;; i++) {
         winrt::com_ptr<IDXGIAdapter> adapter;
@@ -2404,21 +2492,37 @@ std::wstring QueryDataCollectionSession::GetGpuLuidByName(PCWSTR gpu_name,
         }
 
         if (!quiet) {
-            Wh_Log(L"DXGI adapter %u: %s (LUID: 0x%08X_0x%08X)", i,
+            Wh_Log(L"DXGI adapter %u: %s (LUID: 0x%08X_0x%08X, VRAM: %zu)", i,
                    desc.Description, desc.AdapterLuid.HighPart,
-                   desc.AdapterLuid.LowPart);
+                   desc.AdapterLuid.LowPart, desc.DedicatedVideoMemory);
         }
 
-        if (wcsstr(desc.Description, gpu_name)) {
-            WCHAR luid_str[32];
-            swprintf_s(luid_str, L"0x%08X_0x%08X", desc.AdapterLuid.HighPart,
-                       desc.AdapterLuid.LowPart);
-            if (!quiet) {
-                Wh_Log(L"Matched GPU: %s -> LUID %s", desc.Description,
-                       luid_str);
+        // If a name is specified, check for a match.
+        if (gpu_name && *gpu_name) {
+            if (wcsstr(desc.Description, gpu_name)) {
+                best_desc = desc;
+                found = true;
+                break;
             }
-            return luid_str;
+        } else {
+            // Auto-select the one with most VRAM.
+            if (!found ||
+                desc.DedicatedVideoMemory > best_desc.DedicatedVideoMemory) {
+                best_desc = desc;
+                found = true;
+            }
         }
+    }
+
+    if (found) {
+        WCHAR luid_str[32];
+        swprintf_s(luid_str, L"0x%08X_0x%08X", best_desc.AdapterLuid.HighPart,
+                   best_desc.AdapterLuid.LowPart);
+        if (!quiet) {
+            Wh_Log(L"Selected GPU: %s -> LUID %s", best_desc.Description,
+                   luid_str);
+        }
+        return luid_str;
     }
 
     return {};
@@ -2751,6 +2855,12 @@ void DataCollectionSessionInit() {
         IsStrInDateTimePatternSettings(L"%vram_used%");
     metrics[static_cast<int>(MetricType::kVramTotal)] =
         IsStrInDateTimePatternSettings(L"%vram_total%");
+    metrics[static_cast<int>(MetricType::kVramSharedUsage)] =
+        IsStrInDateTimePatternSettings(L"%vram_shared%");
+    metrics[static_cast<int>(MetricType::kVramSharedUsed)] =
+        IsStrInDateTimePatternSettings(L"%vram_shared_used%");
+    metrics[static_cast<int>(MetricType::kVramSharedTotal)] =
+        IsStrInDateTimePatternSettings(L"%vram_shared_total%");
     metrics[static_cast<int>(MetricType::kCpuTemp)] =
         IsStrInDateTimePatternSettings(L"%cpu_temp%") ||
         IsStrInDateTimePatternSettings(L"%cpu_temp_f%");
@@ -3326,6 +3436,59 @@ PCWSTR GetVramTotalFormatted() {
         });
 }
 
+PCWSTR GetVramSharedFormatted() {
+    DataCollectionSampleIfNeeded();
+    return GetMetricFormatted(g_vramSharedFormatted, [](PWSTR buffer,
+                                                        size_t bufferSize) {
+        if (!g_dataCollectionSession) {
+            return false;
+        }
+        std::optional<double> val =
+            g_dataCollectionSession->QueryData(MetricType::kVramSharedUsage);
+        if (!val) {
+            return false;
+        }
+        // Cap to 99 to keep identical width in all cases.
+        int maxVal = 99;
+        FormatPercentValue(static_cast<int>(*val), buffer, bufferSize, maxVal);
+        return true;
+    });
+}
+
+PCWSTR GetVramSharedUsedFormatted() {
+    DataCollectionSampleIfNeeded();
+    return GetMetricFormatted(
+        g_vramSharedUsedFormatted, [](PWSTR buffer, size_t bufferSize) {
+            if (!g_dataCollectionSession) {
+                return false;
+            }
+            std::optional<double> val =
+                g_dataCollectionSession->QueryData(MetricType::kVramSharedUsed);
+            if (!val) {
+                return false;
+            }
+            swprintf_s(buffer, bufferSize, L"%.1f", *val);
+            return true;
+        });
+}
+
+PCWSTR GetVramSharedTotalFormatted() {
+    DataCollectionSampleIfNeeded();
+    return GetMetricFormatted(
+        g_vramSharedTotalFormatted, [](PWSTR buffer, size_t bufferSize) {
+            if (!g_dataCollectionSession) {
+                return false;
+            }
+            std::optional<double> val = g_dataCollectionSession->QueryData(
+                MetricType::kVramSharedTotal);
+            if (!val) {
+                return false;
+            }
+            swprintf_s(buffer, bufferSize, L"%.1f", *val);
+            return true;
+        });
+}
+
 PCWSTR GetCpuTempFormatted() {
     DataCollectionSampleIfNeeded();
     return GetMetricFormatted(
@@ -3523,6 +3686,9 @@ size_t ResolveFormatToken(
         {L"%vram%"sv, GetVramFormatted},
         {L"%vram_used%"sv, GetVramUsedFormatted},
         {L"%vram_total%"sv, GetVramTotalFormatted},
+        {L"%vram_shared%"sv, GetVramSharedFormatted},
+        {L"%vram_shared_used%"sv, GetVramSharedUsedFormatted},
+        {L"%vram_shared_total%"sv, GetVramSharedTotalFormatted},
         {L"%cpu_temp%"sv, GetCpuTempFormatted},
         {L"%cpu_temp_f%"sv, GetCpuTempFFormatted},
         {L"%battery%"sv, GetBatteryFormatted},

--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -1930,6 +1930,12 @@ class QueryDataCollectionSession {
         double sum;
         size_t count;
     };
+    struct DxgiAdapterInfo {
+        std::wstring description;
+        std::wstring luid;
+        SIZE_T dedicated_video_memory;
+        SIZE_T shared_system_memory;
+    };
     std::optional<QueryDataResult> QueryDataWithCount(MetricType type);
     void UpdateMetric(MetricType type);
 
@@ -1941,14 +1947,12 @@ class QueryDataCollectionSession {
         const std::vector<std::wstring>& paths,
         PCWSTR adapter_name,
         bool quiet);
-    static std::wstring GetGpuLuidByName(PCWSTR gpu_name, bool quiet);
-    static std::vector<std::wstring> FilterGpuPathsByAdapterName(
+    std::optional<DxgiAdapterInfo> GetDxgiAdapterInfo(PCWSTR gpu_name,
+                                                      bool quiet);
+    std::vector<std::wstring> FilterGpuPathsByAdapterName(
         const std::vector<std::wstring>& paths,
         PCWSTR gpu_name,
         bool quiet);
-    static void GetDxgiVideoMemory(PCWSTR gpu_name,
-                                   SIZE_T* dedicated,
-                                   SIZE_T* shared);
 
     std::vector<std::wstring> ExpandAndFilterWildcardPaths(MetricType type,
                                                            PCWSTR counter_path,
@@ -1988,6 +1992,11 @@ class QueryDataCollectionSession {
     SIZE_T vram_total_bytes_ = 0;
     SIZE_T vram_shared_total_bytes_ = 0;
     bool vram_total_queried_ = false;
+
+    // Cached DXGI adapter info (queried once per GPU name).
+    std::wstring dxgi_adapter_info_gpu_name_;
+    std::optional<DxgiAdapterInfo> dxgi_adapter_info_;
+    bool dxgi_adapter_info_queried_ = false;
 
     PDH_HQUERY query_;
     MetricData metrics_[static_cast<int>(MetricType::kCount)];
@@ -2225,8 +2234,11 @@ std::optional<double> QueryDataCollectionSession::QueryVramUsed() {
 
 std::optional<double> QueryDataCollectionSession::QueryVramTotal() {
     if (!vram_total_queried_) {
-        GetDxgiVideoMemory(g_settings.dataCollection.gpuAdapterName,
-                           &vram_total_bytes_, &vram_shared_total_bytes_);
+        auto info = GetDxgiAdapterInfo(g_settings.dataCollection.gpuAdapterName, true);
+        if (info) {
+            vram_total_bytes_ = info->dedicated_video_memory;
+            vram_shared_total_bytes_ = info->shared_system_memory;
+        }
         vram_total_queried_ = true;
     }
 
@@ -2256,8 +2268,11 @@ std::optional<double> QueryDataCollectionSession::QueryVramSharedUsed() {
 
 std::optional<double> QueryDataCollectionSession::QueryVramSharedTotal() {
     if (!vram_total_queried_) {
-        GetDxgiVideoMemory(g_settings.dataCollection.gpuAdapterName,
-                           &vram_total_bytes_, &vram_shared_total_bytes_);
+        auto info = GetDxgiAdapterInfo(g_settings.dataCollection.gpuAdapterName, true);
+        if (info) {
+            vram_total_bytes_ = info->dedicated_video_memory;
+            vram_shared_total_bytes_ = info->shared_system_memory;
+        }
         vram_total_queried_ = true;
     }
 
@@ -2268,19 +2283,21 @@ std::optional<double> QueryDataCollectionSession::QueryVramSharedTotal() {
     return std::nullopt;
 }
 
-void QueryDataCollectionSession::GetDxgiVideoMemory(PCWSTR gpu_name,
-                                                    SIZE_T* dedicated,
-                                                    SIZE_T* shared) {
-    if (dedicated) {
-        *dedicated = 0;
+std::optional<QueryDataCollectionSession::DxgiAdapterInfo>
+QueryDataCollectionSession::GetDxgiAdapterInfo(PCWSTR gpu_name, bool quiet) {
+    std::wstring gpu_name_key = gpu_name ? gpu_name : L"";
+    if (dxgi_adapter_info_queried_ &&
+        dxgi_adapter_info_gpu_name_ == gpu_name_key) {
+        return dxgi_adapter_info_;
     }
-    if (shared) {
-        *shared = 0;
-    }
+
+    dxgi_adapter_info_gpu_name_ = gpu_name_key;
+    dxgi_adapter_info_.reset();
+    dxgi_adapter_info_queried_ = true;
 
     winrt::com_ptr<IDXGIFactory> factory;
     if (FAILED(CreateDXGIFactory(IID_PPV_ARGS(factory.put())))) {
-        return;
+        return std::nullopt;
     }
 
     DXGI_ADAPTER_DESC best_desc{};
@@ -2295,6 +2312,12 @@ void QueryDataCollectionSession::GetDxgiVideoMemory(PCWSTR gpu_name,
         DXGI_ADAPTER_DESC desc{};
         if (FAILED(adapter->GetDesc(&desc))) {
             continue;
+        }
+
+        if (!quiet) {
+            Wh_Log(L"DXGI adapter %u: %s (LUID: 0x%08X_0x%08X, VRAM: %zu)", i,
+                   desc.Description, desc.AdapterLuid.HighPart,
+                   desc.AdapterLuid.LowPart, desc.DedicatedVideoMemory);
         }
 
         // If a name is specified, check for a match.
@@ -2314,14 +2337,22 @@ void QueryDataCollectionSession::GetDxgiVideoMemory(PCWSTR gpu_name,
         }
     }
 
-    if (found) {
-        if (dedicated) {
-            *dedicated = best_desc.DedicatedVideoMemory;
-        }
-        if (shared) {
-            *shared = best_desc.SharedSystemMemory;
-        }
+    if (!found) {
+        return std::nullopt;
     }
+
+    WCHAR luid_str[32];
+    swprintf_s(luid_str, L"0x%08X_0x%08X", best_desc.AdapterLuid.HighPart,
+               best_desc.AdapterLuid.LowPart);
+
+    dxgi_adapter_info_ = DxgiAdapterInfo{
+        best_desc.Description,
+        luid_str,
+        best_desc.DedicatedVideoMemory,
+        best_desc.SharedSystemMemory,
+    };
+
+    return dxgi_adapter_info_;
 }
 
 std::optional<double> QueryDataCollectionSession::QueryDataAvg(
@@ -2473,66 +2504,6 @@ QueryDataCollectionSession::FilterNetworkPathsByAdapterName(
     return filtered;
 }
 
-// Get the LUID for a GPU adapter by name using DXGI.
-// If gpu_name is empty, returns the LUID of the adapter with the most VRAM.
-std::wstring QueryDataCollectionSession::GetGpuLuidByName(PCWSTR gpu_name,
-                                                          bool quiet) {
-    winrt::com_ptr<IDXGIFactory> factory;
-    if (FAILED(CreateDXGIFactory(IID_PPV_ARGS(factory.put())))) {
-        return {};
-    }
-
-    DXGI_ADAPTER_DESC best_desc{};
-    bool found = false;
-
-    for (UINT i = 0;; i++) {
-        winrt::com_ptr<IDXGIAdapter> adapter;
-        if (factory->EnumAdapters(i, adapter.put()) == DXGI_ERROR_NOT_FOUND) {
-            break;
-        }
-
-        DXGI_ADAPTER_DESC desc{};
-        if (FAILED(adapter->GetDesc(&desc))) {
-            continue;
-        }
-
-        if (!quiet) {
-            Wh_Log(L"DXGI adapter %u: %s (LUID: 0x%08X_0x%08X, VRAM: %zu)", i,
-                   desc.Description, desc.AdapterLuid.HighPart,
-                   desc.AdapterLuid.LowPart, desc.DedicatedVideoMemory);
-        }
-
-        // If a name is specified, check for a match.
-        if (gpu_name && *gpu_name) {
-            if (wcsstr(desc.Description, gpu_name)) {
-                best_desc = desc;
-                found = true;
-                break;
-            }
-        } else {
-            // Auto-select the one with most VRAM.
-            if (!found ||
-                desc.DedicatedVideoMemory > best_desc.DedicatedVideoMemory) {
-                best_desc = desc;
-                found = true;
-            }
-        }
-    }
-
-    if (found) {
-        WCHAR luid_str[32];
-        swprintf_s(luid_str, L"0x%08X_0x%08X", best_desc.AdapterLuid.HighPart,
-                   best_desc.AdapterLuid.LowPart);
-        if (!quiet) {
-            Wh_Log(L"Selected GPU: %s -> LUID %s", best_desc.Description,
-                   luid_str);
-        }
-        return luid_str;
-    }
-
-    return {};
-}
-
 // Filter GPU paths by adapter name (uses DXGI to map name to LUID).
 std::vector<std::wstring>
 QueryDataCollectionSession::FilterGpuPathsByAdapterName(
@@ -2543,13 +2514,17 @@ QueryDataCollectionSession::FilterGpuPathsByAdapterName(
         Wh_Log(L"Filtering GPU adapters by name: %s", gpu_name);
     }
 
-    // Get the LUID for the GPU name.
-    std::wstring target_luid = GetGpuLuidByName(gpu_name, quiet);
-    if (target_luid.empty()) {
+    auto info = GetDxgiAdapterInfo(gpu_name, quiet);
+    if (!info) {
         if (!quiet) {
             Wh_Log(L"GPU not found by name");
         }
         return {};
+    }
+
+    if (!quiet) {
+        Wh_Log(L"Selected GPU: %s -> LUID %s", info->description.c_str(),
+               info->luid.c_str());
     }
 
     std::vector<std::wstring> filtered;
@@ -2564,14 +2539,14 @@ QueryDataCollectionSession::FilterGpuPathsByAdapterName(
             continue;
         }
 
-        if (_wcsicmp(std::wstring(luid).c_str(), target_luid.c_str()) == 0) {
+        if (_wcsicmp(std::wstring(luid).c_str(), info->luid.c_str()) == 0) {
             filtered.push_back(path);
         }
     }
 
     if (filtered.empty()) {
         if (!quiet) {
-            Wh_Log(L"No GPU paths matched LUID %s", target_luid.c_str());
+            Wh_Log(L"No GPU paths matched LUID %s", info->luid.c_str());
         }
         return {};
     }

--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -85,14 +85,14 @@ patterns can be used:
   * `%ram%` - RAM usage.
   * `%ram_used%` - Used RAM amount in GB.
   * `%ram_total%` - Total RAM amount in GB.
-  * `%ram_commited%` - Committed RAM usage.
-  * `%ram_commited_used%` - Used committed RAM amount in GB.
-  * `%ram_commited_total%` - Total committed RAM amount in GB.
+  * `%ram_committed%` - Committed RAM usage (% of memory reserved by apps, backed by RAM or swap)
+  * `%ram_committed_used%` - Used committed RAM amount in GB.
+  * `%ram_committed_total%` - Total committed RAM amount in GB.
   * `%gpu%` - GPU usage.
   * `%vram%` - VRAM usage as a percentage of total dedicated VRAM.
   * `%vram_used%` - Used dedicated VRAM amount in GB.
   * `%vram_total%` - Total dedicated VRAM amount in GB.
-  * `%vram_shared%` - Shared VRAM usage percentage (RAM borrowed by GPU).
+  * `%vram_shared%` - Shared VRAM (system RAM used as extra GPU memory)
   * `%vram_shared_used%` - Used shared VRAM amount in GB.
   * `%vram_shared_total%` - Total shared VRAM pool size in GB.
   * `%cpu_temp%` - CPU temperature in °C (average of all ACPI thermal zones).
@@ -199,8 +199,7 @@ styles, such as the font color and size.
   $name: GPU adapter name
   $description: >-
     The GPU adapter to use for GPU usage and VRAM metrics. Leave empty to
-    auto-detect (uses the adapter with the most dedicated VRAM for VRAM
-    metrics, sums all adapters for GPU usage). Partial match is supported.
+    auto-detect (uses the adapter with the most dedicated VRAM). Partial match is supported.
     To list adapters, run:
 
     wmic path win32_videocontroller get Name
@@ -3735,9 +3734,9 @@ size_t ResolveFormatToken(
         {L"%ram%"sv, GetRamFormatted},
         {L"%ram_used%"sv, GetRamUsedFormatted},
         {L"%ram_total%"sv, GetRamTotalFormatted},
-        {L"%ram_commited%"sv, GetRamCommitedFormatted},
-        {L"%ram_commited_used%"sv, GetRamCommitedUsedFormatted},
-        {L"%ram_commited_total%"sv, GetRamCommitedTotalFormatted},
+        {L"%ram_committed%"sv, GetRamCommitedFormatted},
+        {L"%ram_committed_used%"sv, GetRamCommitedUsedFormatted},
+        {L"%ram_committed_total%"sv, GetRamCommitedTotalFormatted},
         {L"%gpu%"sv, GetGpuFormatted},
         {L"%vram%"sv, GetVramFormatted},
         {L"%vram_used%"sv, GetVramUsedFormatted},


### PR DESCRIPTION
added 
* ram_used, ram_total,
* ram_commited, ram_commited_used, ram_commited_total 
* vram, vram_used, vram_total (by vendor-agnostic PDH + DXGI)
* vram_shared, vram_shared_used, vram_shared_total
* if adapter is not specified, both vram and gpu are using the adapter with most total VRAM
