### PR TITLE
Fix: slider thumb white edge in TranslucentShell theme

### DIFF
--- a/mods/windows-11-notification-center-styler.wh.cpp
+++ b/mods/windows-11-notification-center-styler.wh.cpp
@@ -473,6 +473,11 @@ const Theme g_themeTranslucentShell = {{
         L"TextAlignment=Center"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.StackPanel#PrimaryAndSecondaryTextContainer > Windows.UI.Xaml.Controls.TextBlock#SubtitleText", {
         L"TextAlignment=Center"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.Thumb#HorizontalThumb > Windows.UI.Xaml.Controls.Border", {
+        L"BorderBrush=Transparent",
+        L"BorderThickness=0,0,0,0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.Thumb#HorizontalThumb > Windows.UI.Xaml.Controls.Border > Windows.UI.Xaml.Shapes.Ellipse#SliderInnerThumb", {
+        L"Stroke=Transparent"}},
 }, {
     L"CommonBgBrush=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#25323232\"/>",
     L"thumbnailImageSize=300",


### PR DESCRIPTION
<img width="581" height="198" alt="屏幕截图 2026-06-13 214713" src="https://github.com/user-attachments/assets/5bb177ab-48c7-4861-81e3-f7a9d81fb5b5" />   

change to  

<img width="568" height="179" alt="屏幕截图 2026-06-14 191303" src="https://github.com/user-attachments/assets/f65f471b-751b-4ae4-8b95-f39a54d58fd3" />
