### PR TITLE
taskbar-primary-on-secondary-monitor: drop stale override monitor

### DIFF
--- a/mods/taskbar-primary-on-secondary-monitor.wh.cpp
+++ b/mods/taskbar-primary-on-secondary-monitor.wh.cpp
@@ -340,6 +340,22 @@ HMONITOR GetTargetMonitor(GetTargetMonitorParams params = {}) {
     }
 
     HMONITOR monitor = g_overrideMonitor;
+    if (monitor) {
+        // The override monitor handle becomes invalid when the display
+        // configuration changes, e.g. when a remote desktop session adds or
+        // removes a virtual display. Since it takes priority over the
+        // configured monitor and is never revalidated, a stale handle would
+        // keep winning and the primary taskbar would end up stuck to a monitor
+        // that no longer exists. Drop it and fall back to the settings.
+        MONITORINFO monitorInfo = {};
+        monitorInfo.cbSize = sizeof(monitorInfo);
+        if (!GetMonitorInfo(monitor, &monitorInfo)) {
+            Wh_Log(L"Override monitor is stale, falling back to settings");
+            g_overrideMonitor = nullptr;
+            monitor = nullptr;
+        }
+    }
+
     if (!monitor) {
         if (*g_settings.monitorInterfaceName.get()) {
             monitor = GetMonitorByInterfaceNameSubstr(


### PR DESCRIPTION
Fixes the taskbar becoming unpainted after a display configuration change, reported in ramensoftware/windhawk-mods#5117 (and possibly ramensoftware/windhawk-mods#5095).

`g_overrideMonitor` stores a raw `HMONITOR` when the primary taskbar is switched by clicking. That handle is invalidated whenever the display configuration changes — a remote desktop session does exactly that by adding or removing a virtual display. Nothing revalidates it, and it is only cleared when `clickToSwitchMonitor` is turned off, so once it goes stale it keeps winning over the configured monitor:

- `TrayUI__SetStuckMonitor_Hook` gets a non-null value and replaces the monitor explorer asked for with the dead one, sticking the taskbar to a monitor that no longer exists.
- `MonitorFromPoint_Hook` / `MonitorFromRect_Hook` return the stale handle rather than falling through, since their guard only catches null.
- `EnumDisplayDevicesW_Hook` bails out at its own `GetMonitorInfo` check, so `DISPLAY_DEVICE_PRIMARY_DEVICE` ends up set on no device.

Setting `monitorInterfaceName` does not help, because the override is checked first.

This validates the handle with `GetMonitorInfo` in `GetTargetMonitor` and falls back to the configured monitor when it is dead. `GetMonitorInfo` is not hooked by the mod, so there is no recursion concern.

### Repro

1. Set `clickToSwitchMonitor` to `middleClick`.
2. Middle click the taskbar's empty space to move the primary taskbar to another monitor.
3. Change the display configuration — connect over RDP, or attach/detach a display.
4. The primary taskbar is no longer painted on any monitor.

### Testing

Built with the bundled Windhawk clang against `windhawk.lib`, clean with `-Wall -Wextra`. Running on Windows 11 Pro 26200 with 4 physical monitors and 3 virtual display adapters (Parsec, an IDD virtual display, and the RDP display adapter). Before the change the two taskbar windows collapsed onto one rectangle after connecting over RDP; after it they land on their own monitors:

```
before:  Shell_TrayWnd           rect=(0,1382)-(2560,1440)
         Shell_SecondaryTrayWnd  rect=(0,1382)-(2560,1440)

after:   Shell_TrayWnd           rect=(0,1382)-(2560,1440)   DISPLAY1
         Shell_SecondaryTrayWnd  rect=(-1440,1378)-(0,1436)  DISPLAY3
```

### Note on scope

This is the minimal fix: it recovers to the configured monitor. It does not preserve the user's click-selected monitor across a display change — persisting the selected monitor's interface name instead of the `HMONITOR` would do that, and I'm happy to rework the PR that way if you prefer it.
