### PR TITLE
Fix FrostyGlass: negative margin on JumpListScroller hid app-specific jump list items

### DIFF
--- a/mods/windows-11-notification-center-styler.wh.cpp
+++ b/mods/windows-11-notification-center-styler.wh.cpp
@@ -3716,7 +3716,7 @@ const Theme g_themeFrostyGlass = {{
         L"Margin=-4.5,-2,-4.5,-2",
         L"Height=Auto"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ScrollViewer#JumpListScroller", {
-        L"Margin=-2"}},
+        L"Margin=0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#SystemItemsContainer > Windows.UI.Xaml.Controls.Border > JumpViewUI.SystemItemListView#SystemItemList", {
         L"Margin:=0,3,0,0"}},
 }, {


### PR DESCRIPTION
fix(FrostyGlass): remove negative margin on JumpListScroller causing empty app jump list items

The -2 margin on ScrollViewer#JumpListScroller was shrinking the
content area enough that JumpListListView#ItemList (app-specific
jump list entries, e.g. browser "New tab" / "New InPrivate window")
failed to render, while JumpViewUI.SystemItemListView#SystemItemList
(Close window, Unpin from taskbar, etc.) was unaffected since it has
a fixed height.